### PR TITLE
bugfix for OP-20338 NoSuchBeanDefinitionException: No qualifying bean of type com.netflix.spectator.api.Registry available issue

### DIFF
--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/PlatformComponents.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/PlatformComponents.java
@@ -24,6 +24,8 @@ import com.netflix.spinnaker.kork.version.VersionResolver;
 import io.github.resilience4j.circuitbreaker.autoconfigure.CircuitBreakersHealthIndicatorAutoConfiguration;
 import io.github.resilience4j.ratelimiter.autoconfigure.RateLimitersHealthIndicatorAutoConfiguration;
 import java.util.List;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ApplicationContext;
@@ -31,7 +33,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-@Configuration
+@AutoConfiguration
 @Import({
   TransientConfigConfiguration.class,
   SpectatorConfiguration.class,

--- a/kork-core/src/main/java/com/netflix/spinnaker/kork/discovery/DiscoveryAutoConfiguration.java
+++ b/kork-core/src/main/java/com/netflix/spinnaker/kork/discovery/DiscoveryAutoConfiguration.java
@@ -22,8 +22,10 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 
-@Configuration
+
+@AutoConfiguration
 @AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
 public class DiscoveryAutoConfiguration {
 

--- a/kork-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/kork-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.netflix.spinnaker.kork.PlatformComponents
+com.netflix.spinnaker.kork.discovery.DiscoveryAutoConfiguration


### PR DESCRIPTION
Fixed as suggested in:
https://github.com/spring-projects/spring-boot/issues/33413
 
The 3.0 [release notes link to the dedicated migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes#upgrading-from-spring-boot-27), which is where most of the information needed when migrating from 2.7 to 3.0 is located.
and 
https://medium.com/spring-boot/auto-configure-your-common-module-in-the-spring-boot-way-32acd3976a70