### PR TITLE
Fixed DiscoveryClient issue

### DIFF
--- a/kork-eureka/kork-eureka.gradle
+++ b/kork-eureka/kork-eureka.gradle
@@ -29,7 +29,7 @@ dependencies {
 
   implementation "com.netflix.archaius:archaius-core:0.7.6"
   implementation "commons-configuration:commons-configuration"
-  implementation "com.netflix.eureka:eureka-client"
+  implementation 'com.netflix.eureka:eureka-core-jersey3:2.0.0'
   implementation "com.netflix.netflix-commons:netflix-eventbus"
   implementation "com.guicedee.services:javax.inject:1.1.1.1-SP1"
 

--- a/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaAutoConfiguration.java
+++ b/kork-eureka/src/main/java/com/netflix/spinnaker/kork/eureka/EurekaAutoConfiguration.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.kork.eureka;
 
 import com.netflix.appinfo.*;
 import com.netflix.discovery.*;
+import com.netflix.discovery.shared.transport.jersey.TransportClientFactories;
+import com.netflix.discovery.shared.transport.jersey3.Jersey3TransportClientFactories;
 import com.netflix.eventbus.impl.EventBusImpl;
 import com.netflix.eventbus.spi.EventBus;
 import com.netflix.spinnaker.kork.discovery.DiscoveryAutoConfiguration;
@@ -41,6 +43,19 @@ public class EurekaAutoConfiguration {
   @Bean
   public EventBus eventBus() {
     return new EventBusImpl();
+  }
+
+  @Bean
+  public DiscoveryClient discoveryClient(
+      ApplicationInfoManager applicationInfoManager,
+      EurekaClientConfig config,
+      TransportClientFactories transportClientFactories) {
+    return new DiscoveryClient(applicationInfoManager, config, transportClientFactories);
+  }
+
+  @Bean
+  public TransportClientFactories transportClientFactories() {
+    return Jersey3TransportClientFactories.getInstance();
   }
 
   @Bean


### PR DESCRIPTION
Earlier, due to update in eureka-client version from 1.10.0 to 2.0.0, it is giving error to create DiscoveryClient bean.
By adding com.netflix.eureka:eureka-core-jersey3:2.0.0, it resolves the issue.