### PR TITLE
fix for config files defaultly taken from location in web module

### DIFF
--- a/kork-cloud-config-server/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigServerBootstrap.java
+++ b/kork-cloud-config-server/src/main/java/com/netflix/spinnaker/kork/configserver/ConfigServerBootstrap.java
@@ -23,7 +23,7 @@ public class ConfigServerBootstrap {
     // of https://github.com/spring-cloud/spring-cloud-commons/issues/466
     defaultSystemProperty(
         "spring.cloud.bootstrap.location",
-        "optional:classpath:/,optional:classpath:/config/,optional:file:./,optional:file:./config/,optional:/opt/spinnaker/config/,optional:${user.home}/.spinnaker/");
+        "optional:/opt/spinnaker/config/,optional:${user.home}/.spinnaker/,optional:classpath:/,optional:classpath:/config/,optional:file:./,optional:file:./config/");
     defaultSystemProperty(
         "spring.cloud.bootstrap.name", "spinnakerconfig,${spring.application.name}config");
     defaultSystemProperty("spring.cloud.config.server.bootstrap", "true");


### PR DESCRIPTION
the cloudprovider accounts are not being populated in UI. The details are updated in the below jira ticket:
[https://devopsmx.atlassian.net/browse/OP-20467?filter=10630](url)