### PR TITLE
Undo oracle.oci.sdk version

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -74,7 +74,7 @@ dependencies {
   api(platform("org.springframework.cloud:spring-cloud-dependencies:${versions.springCloud}"))
   api(platform("io.strikt:strikt-bom:0.31.0"))
   api(platform("org.spockframework:spock-bom:2.4-M1-groovy-4.0"))//1.3-groovy-2.5
-  api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:2.23.0"))//1.5.17"))
+  api(platform("com.oracle.oci.sdk:oci-java-sdk-bom:1.5.17"))
   api(platform("org.testcontainers:testcontainers-bom:1.16.2"))
   api(platform("io.arrow-kt:arrow-stack:${versions.arrow}"))
 


### PR DESCRIPTION
## Summary
**Project Jira :** NA
**Project Doc :** NA

**Issue :** In clouddriver, javax.ws.rs:javax.ws.rs-api dependency is missing due to which TC are not running properly.
**Solution :** javax.ws.rs:javax.ws.rs-api comes from com.oracle.oci.sdk:oci-java-sdk-bom (in kork). Latest version of com.oracle.oci.sdk:oci-java-sdk-bom doesnt contain required dependency, so switched to previous dependency that OSS is using. Previous dependency is vulnerability-free as of now : [Ref](https://mvnrepository.com/artifact/com.oracle.oci.sdk/oci-java-sdk-bom)

### How changes are verified
Now in clouddriver, it is reflecting javax.ws dependency and TC are now atleast running.
Not sure about its impact on other services, but as it used in OSS, assuming it will works well in other services.

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

### Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
Pre deployment steps : NA
Post deployment steps : NA