### PR TITLE
kork(sql): fix for clouddriver-sql and cats-sql failing tests

### DIFF
--- a/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
+++ b/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
@@ -46,7 +46,6 @@ import liquibase.resource.ClassLoaderResourceAccessor;
 import org.jooq.DSLContext;
 import org.jooq.Query;
 import org.jooq.SQLDialect;
-import org.jooq.Table;
 import org.jooq.impl.DataSourceConnectionProvider;
 import org.jooq.impl.DefaultConfiguration;
 import org.jooq.impl.DefaultDSLContext;
@@ -276,7 +275,7 @@ public class SqlTestUtil {
     context.meta().getTables().stream()
         .filter(
             table ->
-                table.getType().isInstance(Table.class)
+                table.getType().isTable()
                     && table.getSchema().getName().equals(schema)
                     && !table.getName().equals(configuration.getDatabaseChangeLogTableName())
                     && !table.getName().equals(configuration.getDatabaseChangeLogLockTableName()))

--- a/kork-sql/kork-sql.gradle
+++ b/kork-sql/kork-sql.gradle
@@ -8,7 +8,9 @@ dependencies {
   api project(":kork-security")
   api "org.springframework:spring-jdbc"
   api "org.springframework:spring-tx"
-  api "org.jooq:jooq"
+  api("org.jooq:jooq:3.13.6"){
+    force(true)
+  }
   api "org.liquibase:liquibase-core"
   api "com.zaxxer:HikariCP"
 


### PR DESCRIPTION
added jooq version same as that in the spinnaker-dependencies.gradle to fix clouddriver-sql and cats-sql failing tests