### PR TITLE
Fixed jooq issue in kork-sql

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -137,15 +137,6 @@ dependencies {
     api("org.jsoup:jsoup:1.15.3")
     api("com.fasterxml.woodstox:woodstox-core:6.4.0")
     api("com.google.oauth-client:google-oauth-client:1.34.1")
-  }
-
-
-/*  api("io.springfox:springfox-swagger-ui:${versions.springfoxSwagger}")
-  api("io.springfox:springfox-swagger2:${versions.springfoxSwagger}")
-  api("org.springdoc:springdoc-openapi-webmvc-core:${versions.openapi}")
-  api("org.springdoc:springdoc-openapi-kotlin:${versions.openapi}") */
-
-  constraints {
     api("com.google.api-client:google-api-client:1.31.1") // TODO: Track update for CVE-2020-7692, reanalysis pending.
     api("cglib:cglib-nodep:3.3.0")
     api("com.jcraft:jsch.agentproxy.connector-factory:${versions.jschAgentProxy}")
@@ -154,7 +145,15 @@ dependencies {
     api("commons-io:commons-io:2.11.0")
     api("io.grpc:grpc-protobuf:1.53.0")
     api("com.google.guava:guava:32.1.1-jre")
+
+    api("org.jooq:jooq:${versions.jooq}")
   }
+
+
+/*  api("io.springfox:springfox-swagger-ui:${versions.springfoxSwagger}")
+  api("io.springfox:springfox-swagger2:${versions.springfoxSwagger}")
+  api("org.springdoc:springdoc-openapi-webmvc-core:${versions.openapi}")
+  api("org.springdoc:springdoc-openapi-kotlin:${versions.openapi}") */
 
   /*constraints {
     api("cglib:cglib-nodep:3.3.0")
@@ -239,8 +238,6 @@ dependencies {
     api("org.jetbrains.spek:spek-junit-platform-engine:${versions.spek}")
     api("org.jetbrains.spek:spek-junit-platform-runner:${versions.spek}")
     api("org.jetbrains.spek:spek-subject-extension:${versions.spek}")
-    api("org.jooq:jooq:${versions.jooq}")
-    api("org.jooq:jooq-kotlin:${versions.jooq}")
     api("org.objenesis:objenesis:2.5.1")
     api("org.pf4j:pf4j:3.2.0")
     api("org.pf4j:pf4j-update:2.3.0")


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20720)
**Project Doc :** [Ref](https://docs.google.com/spreadsheets/d/1bWOLaL3F_Fbe6P6CUyZJOqzMhWxw1j-Sl-9zE0pBtWw/edit#gid=1016245673)

**Issue :** Springboot3 enforces to use jooq:3.17.14 as [jooq:3.17.14](https://mvnrepository.com/artifact/org.jooq/jooq/3.17.14) depends on jakarta. Whereas [jooq:3.13.6](https://mvnrepository.com/artifact/org.jooq/jooq/3.13.6) depends on javax. Orca-sql TCs failing bcoz it is using v3.17.14 as enforced by spriingboot3.

**Solution :** v3.17.14 supports getTableType() inplace of getType() -> [ref](https://github.com/jOOQ/jOOQ/issues/13115)

### How changes are verified
orca-sql TCs passing after making this change in kork & publishing kork to mavenLocal

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** NA