### PR TITLE
Upgrade Jooq version

### DIFF
--- a/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
+++ b/kork-sql-test/src/main/java/com/netflix/spinnaker/kork/sql/test/SqlTestUtil.java
@@ -275,7 +275,7 @@ public class SqlTestUtil {
     context.meta().getTables().stream()
         .filter(
             table ->
-                table.getType().isTable()
+                table.getTableType().isTable()
                     && table.getSchema().getName().equals(schema)
                     && !table.getName().equals(configuration.getDatabaseChangeLogTableName())
                     && !table.getName().equals(configuration.getDatabaseChangeLogLockTableName()))

--- a/kork-sql/kork-sql.gradle
+++ b/kork-sql/kork-sql.gradle
@@ -8,7 +8,10 @@ dependencies {
   api project(":kork-security")
   api "org.springframework:spring-jdbc"
   api "org.springframework:spring-tx"
-  api("org.jooq:jooq:3.13.6"){
+   api("org.jooq:jooq:3.17.14"){
+    force(true)
+  }
+  api("org.jooq:jooq-kotlin:3.17.14"){
     force(true)
   }
   api "org.liquibase:liquibase-core"

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -12,7 +12,8 @@ ext {
     bouncycastle     : "1.70",
     brave            : "5.14.1",//5.12.3",
     gcp              : "25.3.0",
-    jooq             : "3.13.6",
+    jooq             : "3.17.14",
+    jooqKotlin       : "3.17.14",
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
     // spring boot 2.5.14 specifies logback 1.2.11, but a rosco test hung with
@@ -147,6 +148,7 @@ dependencies {
     api("com.google.guava:guava:32.1.1-jre")
 
     api("org.jooq:jooq:${versions.jooq}")
+    api("org.jooq:jooq-kotlin:${versions.jooqKotlin}")
   }
 
 


### PR DESCRIPTION
Following scenarios are handled in current pull request,

1. Added jooq-kotlin for dependent modules to maintain version at kork-oes level for single point of change.
2. Upgraded Jooq version.
3. Fixed a method for table type check.