### PR TITLE
update pf4j version to fix cve

### DIFF
--- a/kork-plugins-api/kork-plugins-api.gradle
+++ b/kork-plugins-api/kork-plugins-api.gradle
@@ -23,7 +23,7 @@ dependencies {
   api "org.slf4j:slf4j-api"
   api "javax.annotation:javax.annotation-api:1.3.2"
   api project(":kork-annotations")
-  api "org.pf4j:pf4j:3.9.0"
+  api "org.pf4j:pf4j:3.10.0"
 
   testImplementation(project(":kork-plugins"))
 }


### PR DESCRIPTION
pf4j version 3.9.0 for all services is still taken from kork-plugins-api module. Changing to 3.10.0 to fix cve. version is set to 3.10.0 already in spinnaker-dependencies.gradle