### PR TITLE
code changes to be compatible with tomcat 10

### DIFF
--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/DefaultTomcatConnectorCustomizer.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/DefaultTomcatConnectorCustomizer.java
@@ -52,10 +52,6 @@ class DefaultTomcatConnectorCustomizer implements TomcatConnectorCustomizer {
   public void customize(Connector connector) {
     this.applySSLSettings(connector);
     this.applyRelaxedURIProperties(connector);
-    if (tomcatConfigurationProperties.getRejectIllegalHeader() != null) {
-      ((AbstractHttp11Protocol<?>) connector.getProtocolHandler())
-          .setRejectIllegalHeader(tomcatConfigurationProperties.getRejectIllegalHeader());
-    }
   }
 
   Ssl copySslConfigurationWithClientAuth(TomcatServletWebServerFactory tomcat) {

--- a/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/TomcatConfigurationProperties.java
+++ b/kork-tomcat/src/main/java/com/netflix/spinnaker/kork/tomcat/TomcatConfigurationProperties.java
@@ -53,7 +53,7 @@ public class TomcatConfigurationProperties {
               "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
               "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"));
 
-  private Boolean rejectIllegalHeader;
+  private final Boolean rejectIllegalHeader = true;
 
   public int getLegacyServerPort() {
     return legacyServerPort;
@@ -107,7 +107,4 @@ public class TomcatConfigurationProperties {
     return rejectIllegalHeader;
   }
 
-  public void setRejectIllegalHeader(Boolean rejectIllegalHeader) {
-    this.rejectIllegalHeader = rejectIllegalHeader;
-  }
 }

--- a/kork-tomcat/src/test/java/com/netflix/spinnaker/kork/tomcat/WebEnvironmentTest.java
+++ b/kork-tomcat/src/test/java/com/netflix/spinnaker/kork/tomcat/WebEnvironmentTest.java
@@ -32,7 +32,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 @TestPropertySource(
     properties = {
       "logging.level.org.apache.coyote.http11.Http11InputBuffer = DEBUG",
-      "default.rejectIllegalHeader = false"
     })
 class WebEnvironmentTest {
 
@@ -53,7 +52,7 @@ class WebEnvironmentTest {
             .toUri();
     ResponseEntity<String> entity =
         restTemplate.exchange(uri, HttpMethod.GET, new HttpEntity<>(headers), String.class);
-    Assertions.assertEquals(HttpStatus.OK, entity.getStatusCode());
+    Assertions.assertEquals(HttpStatus.BAD_REQUEST, entity.getStatusCode());
   }
 
   @SpringBootApplication


### PR DESCRIPTION
The current version of tomcat in kork is 10.1.11, the value rejectIllegalHeader is hard-coded to 'true' in AbstractHttp11Protocol class and the setter for this parameter is also deprecated. So this parameter cannot be configured from TomcatConfigurationProperties class. The purpose of this test is to make sure the configured values from TomcatConfigurationProperties class is picked up to customise the tomcat connector in DefaultTomcatConnectorCustomizer class.

Hence removed configurable logic for rejectIllegalHeader parameterfrom the code as it is no longer accepted.

Reference:
https://tomcat.apache.org/tomcat-10.1-doc/config/http.html