### PR TITLE
fixed kork-sql module testcases

### DIFF
--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlMigrationProperties.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/SqlMigrationProperties.kt
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.kork.sql.config
 
+import liquibase.GlobalConfiguration
+
 /**
  * Defines the configuration properties for connecting to a SQL database for schema migration purposes.
  *
@@ -23,11 +25,13 @@ package com.netflix.spinnaker.kork.sql.config
  * @param password The password to authenticate the [user]
  * @param driver The JDBC driver name
  * @param additionalChangeLogs A list of additional change log paths. This is useful for libraries and extensions.
+ * @param duplicateFileMode flag to handle if multiple files are found in the search path that have duplicate paths.
  */
 data class SqlMigrationProperties(
   var jdbcUrl: String? = null,
   var user: String? = null,
   var password: String? = null,
   var driver: String? = null,
-  var additionalChangeLogs: List<String> = mutableListOf()
+  var additionalChangeLogs: List<String> = mutableListOf(),
+  var duplicateFileMode: GlobalConfiguration.DuplicateFileMode = GlobalConfiguration.DUPLICATE_FILE_MODE.defaultValue
 )

--- a/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt
+++ b/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/migration/SpringLiquibaseProxy.kt
@@ -16,6 +16,8 @@
 package com.netflix.spinnaker.kork.sql.migration
 
 import com.netflix.spinnaker.kork.sql.config.SqlMigrationProperties
+import liquibase.GlobalConfiguration
+import liquibase.Scope
 import javax.sql.DataSource
 import liquibase.integration.spring.SpringLiquibase
 import org.springframework.jdbc.datasource.SingleConnectionDataSource
@@ -52,18 +54,20 @@ class SpringLiquibaseProxy(
     super.afterPropertiesSet()
 
     // Then if anything else has been defined, do that afterwards
-    (sqlMigrationProperties.additionalChangeLogs + korkAdditionalChangelogs)
-      .map {
-        SpringLiquibase().apply {
-          changeLog = "classpath:$it"
-          dataSource = createDataSource()
-          resourceLoader = this@SpringLiquibaseProxy.resourceLoader
-          shouldRun = !sqlReadOnly
+    Scope.child(GlobalConfiguration.DUPLICATE_FILE_MODE.key, sqlMigrationProperties.duplicateFileMode) {
+      (sqlMigrationProperties.additionalChangeLogs + korkAdditionalChangelogs)
+        .map {
+          SpringLiquibase().apply {
+            changeLog = "classpath:$it"
+            dataSource = createDataSource()
+            resourceLoader = this@SpringLiquibaseProxy.resourceLoader
+            shouldRun = !sqlReadOnly
+          }
         }
-      }
-      .forEach {
-        it.afterPropertiesSet()
-      }
+        .forEach {
+          it.afterPropertiesSet()
+        }
+    }
   }
 
   private fun createDataSource(): DataSource =

--- a/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt
+++ b/kork-sql/src/test/kotlin/com/netflix/spinnaker/kork/sql/SpringStartupTests.kt
@@ -39,6 +39,7 @@ import strikt.assertions.isNotNull
     "sql.enabled=true",
     "sql.migration.jdbcUrl=jdbc:h2:mem:test",
     "sql.migration.dialect=H2",
+    "sql.migration.duplicateFileMode=WARN",
     "sql.connectionPool.jdbcUrl=jdbc:h2:mem:test",
     "sql.connectionPool.dialect=H2"
   ]

--- a/kork-sql/src/test/resources/application-test.yml
+++ b/kork-sql/src/test/resources/application-test.yml
@@ -1,12 +1,16 @@
 spring:
-  profiles: test
+  config:
+    activate:
+      on-profile: test
 
 sql:
   enabled: false
 
 ---
 spring:
-  profiles: twodialects
+  config:
+    activate:
+      on-profile: twodialects
 
 sql:
   enabled: true
@@ -26,14 +30,18 @@ sql:
     jdbcUrl: "jdbc:h2:mem:test"
     user:
     password:
+    duplicateFileMode: WARN
   secondaryMigration:
     jdbcUrl: "jdbc:h2:mem:test"
     user:
     password:
+    duplicateFileMode: WARN
 ---
 
 spring:
-  profiles: singledialect
+  config:
+    activate:
+      on-profile: singledialect
 
 sql:
   enabled: true
@@ -52,3 +60,4 @@ sql:
     jdbcUrl: "jdbc:h2:mem:test"
     user:
     password:
+    duplicateFileMode: WARN

--- a/kork-sql/src/test/resources/db/changelog-master.yml
+++ b/kork-sql/src/test/resources/db/changelog-master.yml
@@ -1,1 +1,22 @@
-databaseChangeLog: []
+databaseChangeLog:
+  - changeSet:
+      id: create-sample-table
+      author: kirangodishala
+      changes:
+        - createTable:
+            tableName: sample
+            columns:
+              - column:
+                  name: id
+                  type: boolean
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+        - modifySql:
+            dbms: mysql
+            append:
+              value: " engine innodb"
+      rollback:
+        - dropTable:
+            tableName: sample
+


### PR DESCRIPTION
jira : https://devopsmx.atlassian.net/browse/OP-21387
Test cases in kork-sql module were failing with two exceptions:
1. invalid configuration of spring-profiles and complaining to change from 'spring.profiles' to 'spring.config.activate.on-profile'. Hence changed this in application.yml file
2. Liquibase is complaining of finding duplicate healthcheck.yml file one in src/main/resources and the other in jar files in build directory where as both are same and this is a bug in liquibase for which a workaround was provided to add 'duplicateFileMode: WARN' while configuring liquibase in project. this was already fixed in oss and added the same changes from oss to fix this issue.
Reference for oss PR:
https://github.com/spinnaker/kork/pull/1117

other references:
https://github.com/liquibase/liquibase/pull/3006

Verified that build is successful and test cases are passing 
 