### PR TITLE
Corrected the google-guava contraint in spinnaker-dependencies.gradle

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -143,7 +143,9 @@ dependencies {
     api("mysql:mysql-connector-java:8.0.28")
     api("commons-io:commons-io:2.11.0")
     api("io.grpc:grpc-protobuf:1.53.0")
-    api("com.google.guava:guava:32.1.1-jre")
+    api("com.google.guava:guava") {
+      version "32.1.1-jre"
+    }
     api("org.eclipse.jetty:jetty-http:11.0.16")
     api("org.eclipse.jetty.http2:http2:11.0.16")
     api("org.jooq:jooq:${versions.jooq}")


### PR DESCRIPTION
While fixing the jooq version in clouddriver, I found that clouddriver-core TCs are not running and stucked at issue.
**Issue :**  
`Execution failed for task ':clouddriver-core:compileTestJava'.
> Could not resolve all files for configuration ':clouddriver-core:testCompileClasspath'.
   > Could not resolve com.google.guava:guava:32.1.1-jre.
     Required by:
         project :clouddriver-core > io.spinnaker.kork:kork-bom:1-0-SNAPSHOT
      > Module 'com.google.guava:guava' has been rejected:
           Cannot select module with conflict on capability 'com.google.guava:listenablefuture:1.0' also provided by [com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava(compile)]
   > Could not resolve com.google.guava:guava:31.1-jre.
     Required by:
         project :clouddriver-core > com.google.cloud:google-cloud-secretmanager:2.1.7
      > Module 'com.google.guava:guava' has been rejected:
           Cannot select module with conflict on capability 'com.google.guava:listenablefuture:1.0' also provided by [com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava(compile)]
   > Could not resolve com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava.
     Required by:
         project :clouddriver-core > com.google.cloud:google-cloud-secretmanager:2.1.7
         project :clouddriver-core > com.google.cloud:google-cloud-secretmanager:2.1.7 > com.google.api.grpc:proto-google-cloud-secretmanager-v1:2.1.7
         project :clouddriver-core > com.google.cloud:google-cloud-secretmanager:2.1.7 > com.google.api.grpc:proto-google-cloud-secretmanager-v1beta1:2.1.7
      > Module 'com.google.guava:listenablefuture' has been rejected:
           Cannot select module with conflict on capability 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava' also provided by [com.google.guava:guava:32.1.1-jre(jreApiElements)]
   > Could not resolve com.google.guava:guava:25.0-jre.
     Required by:
         project :clouddriver-core > io.spinnaker.kork:kork-artifacts:1-0-SNAPSHOT > com.hubspot.jinjava:jinjava:2.6.0
      > Module 'com.google.guava:guava' has been rejected:
           Cannot select module with conflict on capability 'com.google.guava:listenablefuture:1.0' also provided by [com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava(compile)]`
           
 **Solution :**
 Checked gradle DI & found com.google.guava:guava:32.1.1-jre is failing to come from kork-bom because of constraint not working properly. Replaced with current syntax.
 
 **Testing :**
1.  build kork -> publish local maven -> ran clouddriver-core TCs -> they are running and passing
2. Ran TCs in kork, didnt find any affect due to this change.
 
 No pre/post deployment tasks
 This change can be rollbacked without any issue.