### PR TITLE
fix for CVE-2023-4759

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -149,6 +149,7 @@ dependencies {
     api("org.eclipse.jetty:jetty-http:11.0.16")
     api("org.eclipse.jetty.http2:http2:11.0.16")
     api("org.jooq:jooq:${versions.jooq}")
+    api("org.eclipse.jgit:org.eclipse.jgit:6.6.1.202309021850-r")
   }
 
 


### PR DESCRIPTION
jira ref: https://devopsmx.atlassian.net/browse/OP-21524

The vulerability is present in 4 services and hence added constraint in kork

verified build was successful in all services and change did not introduce any new unit test failures

Test cases failing is same before and after the change.failing count to total count:
front50-23/68
echo-scheduler-4/51
echo-notifications-1/98
clouddriver-google-17/544
gate-plugins-7/10
gate-core-2/31
orca-core-3/482
orca-peering-6/42
orca-igor-1/149
orca-pipelinetemplate-9/210
orca-queue-sql-28/28
orca-queue-39/505
orca-redis-4/75
orca-retrofit-7/19
orca-sql-6/12
orca-web-4/95
orca-webhook-13/103
orca-bakery-6/107
orca-clouddriver-47/1624
