### PR TITLE
Fix for CVE-2023-6378

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -150,6 +150,8 @@ dependencies {
     api("org.eclipse.jetty.http2:http2:11.0.16")
     api("org.jooq:jooq:${versions.jooq}")
     api("org.eclipse.jgit:org.eclipse.jgit:6.6.1.202309021850-r")
+    api("ch.qos.logback:logback-classic:1.4.14")
+    api("ch.qos.logback:logback-core:1.4.14")
   }
 
 


### PR DESCRIPTION
jira for ref: https://devopsmx.atlassian.net/browse/OP-21508

Added change in kork as this vulnerability is seen in many services.
Verified build is successful and change did not introduce any new test case failures.

Test cases failing before and after the change is same. Failed count/Total count in services :
front50-23/68
echo-scheduler-4/51
echo-notifications-1/98
clouddriver-google-17/544
gate-plugins-7/10
gate-core-2/31
orca-core-3/482
orca-peering-6/42
orca-igor-1/149
orca-pipelinetemplate-9/210
orca-queue-sql-28/28
orca-queue-39/505
orca-redis-4/75
orca-retrofit-7/19
orca-sql-6/12
orca-web-4/95
orca-webhook-13/103
orca-bakery-6/107
orca-clouddriver-47/1624