### PR TITLE
fixing test case in core-tck module

### DIFF
--- a/kork-core-tck/src/main/groovy/com/netflix/spinnaker/kork/lock/BaseLockManagerSpec.groovy
+++ b/kork-core-tck/src/main/groovy/com/netflix/spinnaker/kork/lock/BaseLockManagerSpec.groovy
@@ -127,10 +127,10 @@ abstract class BaseLockManagerSpec<T extends LockManager> extends Specification 
     ensureLockExists(lockOptions.lockName)
 
     when:
-    def response = lockManager.tryReleaseLock(lock, true)
+    def response = lockManager.releaseLock(lock, true)
 
     then:
-    response == LockReleaseStatus.SUCCESS.toString()
+    response == true
 
     ensureLockReleased(lockOptions.lockName)
   }


### PR DESCRIPTION
jira for ref: https://devopsmx.atlassian.net/browse/OP-21387

tryReleaseLock is a private method in RedisLockManager class and this can be accessed by releaseLock method which is public. It returns true if the LockReleaseStatus is SUCCESS. 

Verified build is successful 