### PR TITLE
Reimplemented InstrumentedJedisPool by adding unwrap() to getResource…

### DIFF
--- a/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/telemetry/InstrumentedJedisPool.java
+++ b/kork-jedis/src/main/java/com/netflix/spinnaker/kork/jedis/telemetry/InstrumentedJedisPool.java
@@ -16,19 +16,17 @@
 package com.netflix.spinnaker.kork.jedis.telemetry;
 
 import com.netflix.spectator.api.Registry;
-import org.apache.commons.pool2.PooledObjectFactory;
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.apache.commons.pool2.impl.GenericObjectPool;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 public class InstrumentedJedisPool extends JedisPool {
 
-  private Registry registry;
-  private JedisPool delegated;
-  private String poolName;
+  private final Registry registry;
+  private final JedisPool delegated;
+  private final String poolName;
 
-  // private GenericObjectPool<Jedis> delegateInternalPool = new GenericObjectPool<>(new
-  // JedisFactory());
+  private GenericObjectPool<Jedis> delegateInternalPool;
 
   public InstrumentedJedisPool(Registry registry, JedisPool delegated) {
     this(registry, delegated, "unnamed");
@@ -41,19 +39,31 @@ public class InstrumentedJedisPool extends JedisPool {
   }
 
   @SuppressWarnings("unchecked")
+  public GenericObjectPool<Jedis> getInternalPoolReference() {
+    if (delegateInternalPool == null) {
+      try {
+        delegateInternalPool = (GenericObjectPool<Jedis>) delegated;
+      } catch (Exception e) {
+        throw new IllegalStateException(
+            "Could not typecast JedisPool instance to GenericObjectPool", e);
+      }
+    }
+    return delegateInternalPool;
+  }
+
   @Override
   public Jedis getResource() {
     return new InstrumentedJedis(registry, delegated.getResource(), poolName).unwrap();
   }
 
-  // @Override
-  public void returnResourceObject(Jedis resource) {
-    // super.returnResourceObject(unwrapResource(resource));
+  @Override
+  public void returnResource(Jedis resource) {
+    super.returnResource(unwrapResource(resource));
   }
 
-  // @Override
-  protected void returnBrokenResourceObject(Jedis resource) {
-    // super.returnBrokenResourceObject(unwrapResource(resource));
+  @Override
+  public void returnBrokenResource(Jedis resource) {
+    super.returnBrokenResource(unwrapResource(resource));
   }
 
   @Override
@@ -61,57 +71,40 @@ public class InstrumentedJedisPool extends JedisPool {
     delegated.close();
   }
 
-  // public boolean isClosed() {
-  // return delegated.isClosed();
-  // }
-
-  public void initPool(GenericObjectPoolConfig poolConfig, PooledObjectFactory<Jedis> factory) {
-    // Explicitly not initializing the pool here, as the delegated pool will initialize itself
-  }
+  //  @Override
+  //  public boolean isClosed() {
+  //    return delegated.isClosed();
+  //  }
 
   @Override
   public void destroy() {
     delegated.destroy();
   }
 
-  protected void closeInternalPool() {
-    // Explicitly not calling this; destroy and initPool are the only references to this method
-  }
-
   @Override
   public int getNumActive() {
-    return delegated.getNumActive();
+    return getInternalPoolReference().getNumActive();
   }
 
   @Override
   public int getNumIdle() {
-    return delegated.getNumIdle();
+    return getInternalPoolReference().getNumIdle();
   }
 
   @Override
   public int getNumWaiters() {
-    return delegated.getNumWaiters();
+    return getInternalPoolReference().getNumWaiters();
   }
-
-  // @Override
-  // public long getMeanBorrowWaitTimeMillis() {
-  // return getInternalPoolReference().getMeanBorrowWaitTimeMillis();
-  // }
-  //
-  // @Override
-  // public long getMaxBorrowWaitTimeMillis() {
-  // return getInternalPoolReference().getMaxBorrowWaitTimeMillis();
-  // }
 
   @Override
   public void addObjects(int count) {
     delegated.addObjects(count);
   }
 
-  // private Jedis unwrapResource(Jedis jedis) {
-  // if (jedis instanceof InstrumentedJedis) {
-  // return ((InstrumentedJedis) jedis).unwrap();
-  // }
-  // return jedis;
-  // }
+  private Jedis unwrapResource(Jedis jedis) {
+    if (jedis instanceof InstrumentedJedis) {
+      return ((InstrumentedJedis) jedis).unwrap();
+    }
+    return jedis;
+  }
 }


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-21661)
**Project Doc :** NA

**Issue:** Orca facing issues connecting to redis because in kork getResource() method is not returning Jedis object
```
2024-01-31 08:57:12.188 ERROR 1 --- [0.0-8083-exec-1] c.n.s.k.w.e.GenericExceptionHandlers     : [aman.agrawal@opsmx.io] Internal Server Error
redis.clients.jedis.exceptions.JedisConnectionException: Failed to connect to any host resolved for DNS name.
	at redis.clients.jedis.DefaultJedisSocketFactory.connectToFirstSuccessfulHost(DefaultJedisSocketFactory.java:63)
	at redis.clients.jedis.DefaultJedisSocketFactory.createSocket(DefaultJedisSocketFactory.java:87)
	at redis.clients.jedis.Connection.connect(Connection.java:180)
	at redis.clients.jedis.Connection.sendCommand(Connection.java:152)
	at redis.clients.jedis.Connection.executeCommand(Connection.java:121)
	at redis.clients.jedis.Jedis.zrevrange(Jedis.java:6541)
	at com.netflix.spinnaker.orca.pipeline.persistence.jedis.RedisExecutionRepository.lambda$retrievePipelinesForPipelineConfigId$18(RedisExecutionRepository.java:401)
	at com.netflix.spinnaker.kork.jedis.JedisClientDelegate.withCommandsClient(JedisClientDelegate.java:59)
	at com.netflix.spinnaker.orca.pipeline.persistence.jedis.RedisExecutionRepository.lambda$retrievePipelinesForPipelineConfigId$19(RedisExecutionRepository.java:397)

```
**Solution :** 
Undoing commit : https://github.com/OpsMx/kork-oes/commit/bdde064a0c88e98e9b9dcf7a6a27e4daa208c380
Added unwrap() to getResource() method in InstrumentedJedisPool to get the return object as Jedis type. Previously it is returning object of type:InstrumentedJedis

Original commit : https://github.com/OpsMx/kork-oes/commit/0ab894e1873d4118ac55a45c1ccb213bca25ce24

### How changes are verified
Created local maven kork build -> created orca img -> deployed orca img on cvetarget
Application/pipeline creation/deletion/execution working

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** Regressive testing need to be done at QA end as part of Jan release