### PR TITLE
Fixed CVE-2023-34053 - Upgraded spring-webmvc

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -154,6 +154,7 @@ dependencies {
     api("ch.qos.logback:logback-core:1.4.14")
     api("io.projectreactor.netty:reactor-netty-http:1.1.13")
     api("com.jayway.jsonpath:json-path:2.9.0")
+    api("org.springframework:spring-webmvc:6.0.14")
   }
 
 


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-21527)
**Project Doc :** NA

**Issue :** CVE-2023-34053
**Solution :** Upgraded spring-webmvc

### How changes are verified
kork-build successfull, all TCs passing
build local kork maven, build orca, igor & echo imgs locally, ran trivy on these imgs - mentioned CVE not found
deployed orca, igor, echo imgs on cvetarget -> app/pipeline creation/deletion/execution are working
Img info : aman1603/orca:2feb2, igor:2feb3, echo:2feb2

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** QA will do regression testing