### PR TITLE
OP-21844 Fixed postgresql cve by upgrading it to 4.7.2. CVE-2024-1597

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -113,6 +113,7 @@ dependencies {
 
   constraints{
     api("org.yaml:snakeyaml:2.0")
+    api("org.postgresql:postgresql:42.7.2")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0")
     api("org.liquibase:liquibase-core:4.21.0")
     api("org.json:json:20231013")


### PR DESCRIPTION
Jira : https://devopsmx.atlassian.net/browse/OP-21844
Summary : Upgraded postgresql version 
Testing :

compile successful, no new TCs failed bcoz of this.

Created trivy-scan locally, this CVE not found
Pre-merge : NA
Post-merge : QA regression testing