### PR TITLE
OP-21856 Fixed CVE-2023-39017 - Upgraded Quartz version

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -144,5 +144,6 @@ dependencies {
     api("com.jayway.jsonpath:json-path:2.9.0")
     api("org.springframework:spring-webmvc:6.0.14")
     api("org.springdoc:springdoc-openapi-starter-webmvc-ui:${versions.springdocVersion}")
+    api("org.quartz-scheduler:quartz:2.5.0-rc1")
   }
 }


### PR DESCRIPTION
**Jira** : https://devopsmx.atlassian.net/browse/OP-21856
**Summary** : Upgraded quartz version
Springboot dependency brings quartz v2.3.2 [ref](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/3.0.9), v2.3.2 hav vulnerability, hence added latest version to spinnaker-gradle.dependencies: [ref](https://mvnrepository.com/artifact/org.quartz-scheduler/quartz)
**Testing** :
1. compile successful, no new TCs failed bcoz of this.
2. Build kork-changes & publish it to local maven, build echo, create docker image : aman1603/echo:5march1, deployed to cvetarget ns, cron pipeline reran successful : [ref](https://deck.cve.opsmx.net/#/applications/aman/executions?pipeline=cron)
3. Created trivy-scan locally, this CVE not found

**Pre-merge** : NA
**Post-merge** : QA regression testing