### PR TITLE
OP-21878 Upgraded tomcat-embed-core to fix CVE-2023-46589

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -144,5 +144,6 @@ dependencies {
     api("org.springframework:spring-webmvc:6.0.14")
     api("org.springdoc:springdoc-openapi-starter-webmvc-ui:${versions.springdocVersion}")
     api("org.quartz-scheduler:quartz:2.5.0-rc1")
+    api("org.apache.tomcat.embed:tomcat-embed-core:10.1.16")
   }
 }


### PR DESCRIPTION
**Jira** : https://devopsmx.atlassian.net/browse/OP-21878
**Summary** : Upgraded tomcat-embed-core
**Testing** :
compile successful in all spinnaker services, no new TCs failed bcoz of this.
publish kork local maven, did DI on multiple services, picking latest version as mentioned in kork
generate local trivy scan on multiple services docker imgs, this CVE not found
ran multiple service, they started successfully after this change.

**Pre_merge** : NA
**Post_merge** : QA regression testing