### PR TITLE
OP-21879 - Fixed CVE-2023-3635 by upgrading okio-jvm

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.7.21
+kotlinVersion=1.9.21
 org.gradle.parallel=true
 spinnakerGradleVersion=1-0-SNAPSHOT
 #targetJava11=true

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -145,5 +145,7 @@ dependencies {
     api("org.springdoc:springdoc-openapi-starter-webmvc-ui:${versions.springdocVersion}")
     api("org.quartz-scheduler:quartz:2.5.0-rc1")
     api("org.apache.tomcat.embed:tomcat-embed-core:10.1.16")
+    api("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
+    api("com.squareup.okio:okio-jvm:3.8.0")
   }
 }


### PR DESCRIPTION
**Jira** : https://devopsmx.atlassian.net/browse/OP-21879
**Summary** : Upgraded [okio-jvm](https://mvnrepository.com/artifact/com.squareup.okio/okio-jvm) with supported [kotlin](https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib) version
**Testing** :
compile successful in all spinnaker services, no new TCs failed bcoz of this.
publish kork local maven, did DI on multiple services, picking latest version as mentioned in kork
generate local trivy scan on multiple services docker imgs, this CVE not found
ran multiple service, they started successfully after this change.

**Pre_merge** : NA
**Post_merge** : QA regression testing