### PR TITLE
OP-22334 Upgraded postgres sql version from 42.5.4 to 42.5.5. CVE-2024-1597

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ if (spinnakerGradleVersion.endsWith('-SNAPSHOT')) {
       mavenLocal()
       gradlePluginPortal()
       maven{
-        url "NEXUS_URL"
+        url "https://nexus1.opsmx.net/repository/maven-snapshots/"
           credentials {
             username = "NEXUS_USERNAME"
             password = "NEXUS_PASSWORD"

--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -179,5 +179,6 @@ dependencies {
     api("org.apache.tomcat.embed:tomcat-embed-core:${versions.tomcat}")
     api("org.apache.tomcat.embed:tomcat-embed-el:${versions.tomcat}")
     api("org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcat}")
+    api("org.postgresql:postgresql:42.5.5")
   }
 }


### PR DESCRIPTION
OP-21844 Upgraded postgres sql version from 42.5.4 to 42.5.5. CVE-2024-1597

Jira : https://devopsmx.atlassian.net/browse/OP-22334
Summary : Upgraded postgres jar from 42.5.4 to 42.5.5
Testing :compile successful, no new TCs failed bcoz of this.
clouddriver, front50, kayenta, orca, fiat services started successfully after this change.
Created trivy-scan locally, this CVE not found
Pre-merge : NA
Post-merge : QA regression testing